### PR TITLE
All-Sessions Page, Feedback page, and UI updates

### DIFF
--- a/lib/chatbot-api/functions/feedback-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/feedback-handler/lambda_function.py
@@ -148,12 +148,18 @@ def download_feedback(event):
 def get_feedback(event):
     try:
         query_params = event.get('queryStringParameters', {})
-        start_time = query_params.get('startTime')
-        end_time = query_params.get('endTime')
-        
-        # Initialize the response and items list
-        response = None
-        items = []
+        # session_id = query_params.get('session_id')
+        # start_time = query_params.get('startTime') + "T00:00:00"
+        # end_time = query_params.get('endTime') + "T23:59:59"
+
+        # query_kwargs = {
+        #     'IndexName': 'SessionMessagesIndex',
+        #     'KeyConditionExpression': Key('sk_session_id').eq(session_id) & Key('created_at').between(start_time, end_time),
+        #     'FilterExpression': Attr('feedback_type').exists(),
+        #     'ScanIndexForward': False
+        # }
+
+        # response = messages_table.query(**query_kwargs)
 
         """
         Interpretated that this function lists all sessions with the chat bot because the frontend UI 
@@ -164,7 +170,6 @@ def get_feedback(event):
         time attribute already has "T00:00:00" appended
         Updated labels in formatted_feedback
         """
-<<<<<<< Updated upstream
         start_time = query_params.get('startTime')
         end_time = query_params.get('endTime')
         topic = query_params.get('topic')
@@ -172,27 +177,6 @@ def get_feedback(event):
             FilterExpression=Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_type').exists()
         )
         items = response.get('Items', [])
-=======
-
-        # Loop to handle pagination
-        while True:
-            # Add ExclusiveStartKey if this is a continuation of a previous query
-            if response and 'LastEvaluatedKey' in response:
-                response = messages_table.scan(
-                    FilterExpression=Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_type').exists(),
-                    ExclusiveStartKey=response['LastEvaluatedKey']
-                )
-            else:
-                response = messages_table.scan(
-                    FilterExpression=Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_type').exists()
-                )
-            
-            items.extend(response.get('Items', []))
-
-            # Break if there are no more items to fetch
-            if 'LastEvaluatedKey' not in response:
-                break
->>>>>>> Stashed changes
 
         formatted_feedback = [
             {

--- a/lib/chatbot-api/functions/feedback-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/feedback-handler/lambda_function.py
@@ -173,8 +173,15 @@ def get_feedback(event):
         start_time = query_params.get('startTime')
         end_time = query_params.get('endTime')
         topic = query_params.get('topic')
+
+        filter_expression = Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_type').exists()
+        if topic in {"Positive", "Negative"}:
+            filter_expression = Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_type').eq(topic.lower())
+        elif topic in {"Error Messages", "Not Clear", "Poorly Formatted", "Inaccurate", "Not Relevant to My Question", "Other"}:
+            filter_expression = Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_category').eq(topic)
+
         response = messages_table.scan(
-            FilterExpression=Key('feedback_created_at').between(start_time, end_time) & Attr('feedback_type').exists()
+            FilterExpression=filter_expression
         )
         items = response.get('Items', [])
 

--- a/lib/chatbot-api/functions/session-handler/lambda_function.py
+++ b/lib/chatbot-api/functions/session-handler/lambda_function.py
@@ -26,6 +26,9 @@ class DecimalEncoder(json.JSONEncoder):
 def _generate_message_id():
     return f"MESSAGE-{int(datetime.now().timestamp())}-{uuid.uuid4().hex[:8]}"
 
+def _generate_review_id():
+    return f"REVIEW-{int(datetime.now().timestamp())}-{uuid.uuid4().hex[:8]}"
+
 def add_new_session_with_first_message(session_id, user_id, title, first_chat_entry):
     try:
         session_id = session_id
@@ -114,7 +117,7 @@ def add_message_to_existing_session(session_id, new_chat_entry):
             'body': json.dumps(str(error))
         }
 
-def get_session(session_id, user_id):
+def get_session(session_id, user_id, isAdmin):
     """
     Add message_id to chat_history JSON so that it can be parsed by the frontend 
     for the get_feedback() function inside feedback handler Lambda function
@@ -139,15 +142,33 @@ def get_session(session_id, user_id):
 
         messages = messages_response.get('Items', [])
         
-        chat_history = [
-            {
-                "user": message.get("user_prompt", ""),
-                "chatbot": message.get("bot_response", ""),
-                "metadata": json.dumps(message.get("sources", [])),
-                "messageId": message.get("pk_message_id", "")
-            }
-            for message in messages
-        ]
+        if isAdmin:
+            chat_history = [
+                {
+                    "user": message.get("user_prompt", ""),
+                    "chatbot": message.get("bot_response", ""),
+                    "metadata": json.dumps(message.get("sources", [])),
+                    "messageId": message.get("pk_message_id", ""),
+                    "userFeedback": {
+                        "feedbackType": message.get("feedback_type", "").title(),
+                        "feedbackCategory": message.get("feedback_category", ""),
+                        "feedbackMessage": message.get("feedback_message", ""),
+                        "feedbackRank": str(message.get("feedback_rank", ""))
+                    }
+                }
+                for message in messages
+            ]
+        else:
+            chat_history = [
+                {
+                    "user": message.get("user_prompt", ""),
+                    "chatbot": message.get("bot_response", ""),
+                    "metadata": json.dumps(message.get("sources", [])),
+                    "messageId": message.get("pk_message_id", ""),
+                    "userFeedback": {}
+                }
+                for message in messages
+            ]
 
         session_data["chat_history"] = chat_history
 
@@ -270,7 +291,7 @@ def list_sessions_by_user_id(user_id, limit=15):
     return formatted_items
 
 
-def list_all_sessions(start_time, end_time, has_feedback, has_review, limit=250):
+def list_all_sessions(start_time, end_time, has_feedback, has_review, user_id, limit=250):
     # Get all (or first 250) sessions from sessions table
     items = []
     last_evaluated_key = None
@@ -315,13 +336,34 @@ def list_all_sessions(start_time, end_time, has_feedback, has_review, limit=250)
         if not last_evaluated_key:
             break
 
+    # Get list of session IDs that have at least 1 review
+    sessions_with_review = {}
+    while True:
+        if last_evaluated_key:
+            response = reviews_table.scan(
+                FilterExpression=Attr('reviewed_by').eq(user_id),
+                ExclusiveStartKey=last_evaluated_key
+            )
+        else: 
+            response = reviews_table.scan(
+                FilterExpression=Attr('reviewed_by').eq(user_id)
+            )
+        last_evaluated_key = response.get('LastEvaluatedKey')
+
+        scan_items = response.get('Items', [])
+        for item in scan_items:
+            sessions_with_review[item["session_id"]] = item["pk_review_id"]
+        if not last_evaluated_key:
+            break
 
     formatted_items = [
         {
             "session_id": item["pk_session_id"],
             "title": item["title"].strip(),
             "time_stamp": item["created_at"],
-            "has_feedback": ("Yes" if item["pk_session_id"] in sessions_with_feedback else "No")
+            "has_feedback": ("Yes" if item["pk_session_id"] in sessions_with_feedback else "No"),
+            "has_review": ("Yes" if item["pk_session_id"] in sessions_with_review else "No"),
+            "review_id": sessions_with_review.get(item["pk_session_id"],"")
         }
         for item in items
     ]
@@ -331,8 +373,79 @@ def list_all_sessions(start_time, end_time, has_feedback, has_review, limit=250)
             item for item in formatted_items if item["has_feedback"].lower() == has_feedback 
         ]
 
+    if has_review in {"yes", "no"}:
+        formatted_items = [
+            item for item in formatted_items if item["has_review"].lower() == has_review
+        ]
+
     return formatted_items
 
+
+def update_review_session(review_id, session_id, user_id):
+    """
+    Create or update review session by an admin user.
+    Each entry can be uniquely identified by session id + user id
+    """
+    
+    try:
+        if review_id:
+            reviews_table.update_item(
+                Key={'pk_review_id': review_id},
+                UpdateExpression="SET reviewed_by = :reviewed_by, reviewed_at = :reviewed_at",
+                ExpressionAttributeValues={
+                    ':reviewed_by': user_id,
+                    ':reviewed_at': datetime.now().isoformat()
+                }
+            )
+        else:
+            review_id = _generate_review_id()
+
+            reviews_table.put_item(
+                Item={
+                    'pk_review_id': review_id,
+                    'session_id': session_id,
+                    'reviewed_by': user_id,
+                    'comments': "",
+                    'reviewed_at': datetime.now().isoformat()
+                }
+            )
+
+        return {
+            'statusCode': 200,
+            'headers': {'Access-Control-Allow-Origin': '*'},
+            'body': json.dumps({
+                "review_id": review_id,
+                "session_id": session_id
+            })
+        }
+
+    except ClientError as error:
+        print(f"Error adding message to session {session_id}: {error}")
+        return {
+            'statusCode': 500,
+            'headers': {'Access-Control-Allow-Origin': '*'},
+            'body': json.dumps(str(error))
+        }
+
+
+def delete_review_session(review_id, session_id, user_id):
+    try:
+        if review_id:
+            reviews_table.delete_item(Key={'pk_review_id': review_id})
+        
+        return {
+            'statusCode': 200,
+            'headers': {'Access-Control-Allow-Origin': '*'},
+            'body': json.dumps(f"Review {review_id} deleted.")
+        }
+    except ClientError as error:
+        print(f"DynamoDB ClientError: {error}")
+        return {
+            'statusCode': 500,
+            'headers': {'Access-Control-Allow-Origin': '*'},
+            'body': json.dumps(str(error))
+        }
+    
 
 def assemble_chat_history(session_id):
     """
@@ -365,6 +478,15 @@ def assemble_chat_history(session_id):
         return []
 
 def lambda_handler(event, context):
+    isAdmin = False
+    try:
+        request_context = event["requestContext"]["authorizer"]["jwt"]["claims"]
+        if "Admin" in request_context["cognito:groups"]:
+            isAdmin = True
+    except:
+        print("Could not check for Admin role")
+        print(event)
+
     data = json.loads(event['body'])
     operation = data.get('operation')
     
@@ -381,7 +503,7 @@ def lambda_handler(event, context):
             data['new_chat_entry']
         )
     elif operation == 'get_session':
-        return get_session(data['session_id'], data['user_id'])
+        return get_session(data['session_id'], data['user_id'], isAdmin)
     elif operation == 'update_session':
         return update_session(data['session_id'], data['user_id'], data['new_chat_entry'])
     elif operation == 'list_sessions_by_user_id':
@@ -389,11 +511,15 @@ def lambda_handler(event, context):
     elif operation == 'list_all_sessions_by_user_id':
         return list_sessions_by_user_id(data['user_id'],limit=100)
     elif operation == 'list_all_sessions':
-        return list_all_sessions(data['start_time'], data['end_time'], data['has_feedback'], data['has_review'], limit=250)
+        return list_all_sessions(data['start_time'], data['end_time'], data['has_feedback'], data['has_review'], data['user_id'], limit=250)
     elif operation == 'delete_session':
         return delete_session(data['session_id'], data['user_id'])
     elif operation == 'assemble_chat_history':
         return assemble_chat_history(data['session_id'])
+    elif operation == 'update_review_session':
+        return update_review_session(data['review_id'], data['session_id'], data['user_id'])
+    elif operation == 'delete_review_session':
+        return delete_review_session(data['review_id'], data['session_id'], data['user_id'])
     else:
         return {
             'statusCode': 400,

--- a/lib/chatbot-api/functions/websocket-chat/index.mjs
+++ b/lib/chatbot-api/functions/websocket-chat/index.mjs
@@ -180,6 +180,7 @@ const getUserResponse = async (id, requestJSON) => {
       let sessionData = {};
       try {
           sessionData = JSON.parse(result);
+          sessionData = JSON.parse(sessionData.body);
       } catch (error) {
           console.error("Failed to parse session data:", error);
       }
@@ -227,7 +228,25 @@ const getUserResponse = async (id, requestJSON) => {
             FunctionName: process.env.SESSION_HANDLER,
             Payload: JSON.stringify(addSessionRequest),
         });
-        await client.send(addCommand);
+        const { Payload } = await client.send(addCommand);
+        const PayloadString = Buffer.from(Payload).toString();
+        let MessageId = JSON.parse(PayloadString).body;
+        MessageId = JSON.parse(MessageId).message_id;
+        console.log("Message metadata (existing session):");
+        console.log(MessageId);
+
+        // Testing sending message ID to frontend client
+        console.log("sending message ID to client");
+        try {
+          let messageParams = {
+            ConnectionId: id,
+            Data: `<!MessageId!>: ${MessageId}`
+          };
+          const command = new PostToConnectionCommand(messageParams);
+          await wsConnectionClient.send(command);
+        } catch (error) {
+          console.error("Error sending metadata:", error);
+        }
       } else {
         // Add message to existing session
         const addMessageRequest = {
@@ -242,7 +261,25 @@ const getUserResponse = async (id, requestJSON) => {
             FunctionName: process.env.SESSION_HANDLER,
             Payload: JSON.stringify(addMessageRequest),
         });
-        await client.send(addCommand);
+        const { Payload } = await client.send(addCommand);
+        const PayloadString = Buffer.from(Payload).toString();
+        let MessageId = JSON.parse(PayloadString).body;
+        MessageId = JSON.parse(MessageId).message_id;
+        console.log("Message metadata (existing session):");
+        console.log(MessageId);
+
+        // Testing sending message ID to frontend client
+        console.log("sending message ID to client");
+        try {
+          let messageParams = {
+            ConnectionId: id,
+            Data: `<!MessageId!>: ${MessageId}`
+          };
+          const command = new PostToConnectionCommand(messageParams);
+          await wsConnectionClient.send(command);
+        } catch (error) {
+          console.error("Error sending metadata:", error);
+        }
     }
     const input = {
       ConnectionId: id,

--- a/lib/user-interface/app/src/common/api-client/user-feedback-client.ts
+++ b/lib/user-interface/app/src/common/api-client/user-feedback-client.ts
@@ -64,10 +64,10 @@ export class UserFeedbackClient {
 
   }
 
-  async getUserFeedback(topic: string, startTime?: string, endTime?: string, nextPageToken?: string) {
+  async getUserFeedback(topic: string, startTime?: string, endTime?: string) {
 
     const auth = await Utils.authenticate();
-    let params = new URLSearchParams({ topic, startTime, endTime, nextPageToken });
+    let params = new URLSearchParams({ topic, startTime, endTime });
 
     /** If the parameters are undefined, we don't want those being passed to the API, so 
      * this will delete any undefined parameters if needed. Admittedly, the API should handle this

--- a/lib/user-interface/app/src/common/constants.ts
+++ b/lib/user-interface/app/src/common/constants.ts
@@ -30,12 +30,12 @@ export const languageList = [
 export const feedbackCategories = [
   {label: "All Positive Responses", value:"Positive", disabled: false},
   {label: "All Negative Responses", value:"Negative", disabled: false},
-  {label: " Error Messages", value:"Error Messages", disabled: false},
-  {label: " Not Clear", value:"Not Clear", disabled: false},
-  {label: " Poorly Formatted", value:"Poorly Formatted", disabled: false},
-  {label: " Inaccurate", value:"Inaccurate", disabled: false},
-  {label: " Not Relevant to Question", value:"Not Relevant to My Question", disabled: false},
-  {label: " Other", value:"Other", disabled: false}, 
+  {label: "Error Messages", value:"Error Messages", disabled: false},
+  {label: "Not Clear", value:"Not Clear", disabled: false},
+  {label: "Poorly Formatted", value:"Poorly Formatted", disabled: false},
+  {label: "Inaccurate", value:"Inaccurate", disabled: false},
+  {label: "Not Relevant to Question", value:"Not Relevant to My Question", disabled: false},
+  {label: "Other", value:"Other", disabled: false}, 
 ]
 
 export const feedbackTypes = [

--- a/lib/user-interface/app/src/common/types.ts
+++ b/lib/user-interface/app/src/common/types.ts
@@ -27,4 +27,5 @@ export interface NavigationPanelState {
 export type LoadingStatus = "pending" | "loading" | "finished" | "error";
 export type AdminDataType =
   | "file"
-  | "feedback";
+  | "feedback"
+  | "session";

--- a/lib/user-interface/app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/app/src/components/chatbot/chat-input-panel.tsx
@@ -262,7 +262,15 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
           console.log(sources);
         }
 
-        // Update the chat history state with the new message        
+        let messageId = "";
+        const receivedDataSplit = receivedData.split("<!MessageId!>:");
+        // Parse streamed data for message Id at the end
+        if (receivedData.includes("<!MessageId!>:")){
+          messageId = receivedDataSplit[1].trim();
+          console.log("Received Message Id: ");
+          console.log(messageId);
+        }
+        // Update the chat history state with the new message      
         messageHistoryRef.current = [
           ...messageHistoryRef.current.slice(0, -2),
 
@@ -270,13 +278,13 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
             type: ChatBotMessageType.Human,
             content: messageToSend,
             metadata: {},
-            messageId: "",
+            messageId: messageId,
           },
           {
             type: ChatBotMessageType.AI,            
-            content: receivedData,
+            content: receivedDataSplit[0],
             metadata: sources,
-            messageId: "",
+            messageId: messageId,
           },
         ];        
         props.setMessageHistory(messageHistoryRef.current);        

--- a/lib/user-interface/app/src/components/chatbot/chat-input-panel.tsx
+++ b/lib/user-interface/app/src/components/chatbot/chat-input-panel.tsx
@@ -162,12 +162,20 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
           metadata: {            
           },
           messageId: "",
+          userFeedback: {},
+          userId: "",
+          title: "",
+          createdAt: "",
         },
         {
           type: ChatBotMessageType.AI,          
           content: receivedData,
           metadata: {},
           messageId: "",
+          userFeedback: {},
+          userId: "",
+          title: "",
+          createdAt: "",
         },
       ];
       props.setMessageHistory(messageHistoryRef.current);
@@ -199,6 +207,10 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
           content: `Sorry, I had a bit of trouble processing that question, please type it again in the search bar. I'll try my best to help you with your questions.`,
           metadata: {},
           messageId: "",
+          userFeedback: {},
+          userId: "",
+          title: "",
+          createdAt: "",
         })
       }},60000)
 
@@ -279,12 +291,20 @@ export default function ChatInputPanel(props: ChatInputPanelProps) {
             content: messageToSend,
             metadata: {},
             messageId: messageId,
+            userFeedback: {},
+            userId: "",
+            title: "",
+            createdAt: "",
           },
           {
             type: ChatBotMessageType.AI,            
             content: receivedDataSplit[0],
             metadata: sources,
             messageId: messageId,
+            userFeedback: {},
+            userId: "",
+            title: "",
+            createdAt: "",
           },
         ];        
         props.setMessageHistory(messageHistoryRef.current);        

--- a/lib/user-interface/app/src/components/chatbot/chat-message.tsx
+++ b/lib/user-interface/app/src/components/chatbot/chat-message.tsx
@@ -65,6 +65,8 @@ export default function ChatMessage(props: ChatMessageProps) {
     setSelectedIssue(null);
     setSelectedRankValue(null);
     setFeedbackMessage("");
+    console.log("user feedback");
+    console.log(formatUserFeedback(props.message));
   };
 
   const handleRadioChange = (event) => {
@@ -83,7 +85,14 @@ export default function ChatMessage(props: ChatMessageProps) {
 
   const showSources = props.message.metadata?.Sources && (props.message.metadata.Sources as any[]).length > 0;
   
-
+  const formatUserFeedback = (message) => {
+    const userFeedbackType = message.userFeedback?.feedbackType ? message.userFeedback.feedbackType: "N/A";
+    const userFeedbackCategory = message.userFeedback?.feedbackCategory ? " -- " + message.userFeedback.feedbackCategory: "";
+    const userFeedbackRank = message.userFeedback?.feedbackRank ? " (" + message.userFeedback.feedbackRank + "/5)": "";
+    const userFeedbackMessage = message.userFeedback?.feedbackMessage ? ": " + message.userFeedback.feedbackMessage: "";
+    return "#### USER COMMENT:\n```\n" + userFeedbackType + userFeedbackCategory + userFeedbackRank + userFeedbackMessage + "\n```";
+  };
+  
   return (
     <div>
       <Modal
@@ -296,6 +305,44 @@ export default function ChatMessage(props: ChatMessageProps) {
               />
             )}
           </div>
+          {isAdmin && (<ReactMarkdown
+            children={formatUserFeedback(props.message)}
+            remarkPlugins={[remarkGfm]}
+            components={{
+              pre(props) {
+                const { children, ...rest } = props;
+                return (
+                  <pre {...rest} className={styles.markdownContainer}>
+                    {children}
+                  </pre>
+                );
+              },
+              table(props) {
+                const { children, ...rest } = props;
+                return (
+                  <table {...rest} className={styles.markdownTable}>
+                    {children}
+                  </table>
+                );
+              },
+              th(props) {
+                const { children, ...rest } = props;
+                return (
+                  <th {...rest} className={styles.markdownTableCell}>
+                    {children}
+                  </th>
+                );
+              },
+              td(props) {
+                const { children, ...rest } = props;
+                return (
+                  <td {...rest} className={styles.markdownTableCell}>
+                    {children}
+                  </td>
+                );
+              },
+            }}
+          />)}
         </Container>
       )}
       {loading && (

--- a/lib/user-interface/app/src/components/chatbot/chat.tsx
+++ b/lib/user-interface/app/src/components/chatbot/chat.tsx
@@ -98,7 +98,7 @@ export default function Chat(props: { sessionId?: string}) {
   const parseTitle = (title: string, timestamp: string, userId: string) => {
     const dateObject = new Date(timestamp);
     const dateString = dateObject.toLocaleDateString("en-US", {hour: "numeric", minute: "numeric"});
-    return `${title} | ${dateString} | User ID:${userId}`;
+    return `${title} | ${dateString} | User ID: ${userId}`;
   }
 
   /** Adds some metadata to the user's feedback */

--- a/lib/user-interface/app/src/components/chatbot/chat.tsx
+++ b/lib/user-interface/app/src/components/chatbot/chat.tsx
@@ -5,7 +5,7 @@ import {
   FeedbackData
 } from "./types";
 import { Auth } from "aws-amplify";
-import { SpaceBetween, StatusIndicator, Alert, Flashbar } from "@cloudscape-design/components";
+import { SpaceBetween, StatusIndicator, Alert, Flashbar, Header, Link, Box } from "@cloudscape-design/components";
 import { v4 as uuidv4 } from "uuid";
 import { AppContext } from "../../common/app-context";
 import { ApiClient } from "../../common/api-client/api-client";
@@ -14,9 +14,11 @@ import ChatInputPanel, { ChatScrollState } from "./chat-input-panel";
 import styles from "../../styles/chat.module.scss";
 import { CHATBOT_NAME } from "../../common/constants";
 import { useNotifications } from "../notif-manager";
+import { useAdmin } from "../../common/admin-context.js";
 
 export default function Chat(props: { sessionId?: string}) {
   const appContext = useContext(AppContext);
+  const isAdmin = useAdmin();
   const [running, setRunning] = useState<boolean>(true);
   const [session, setSession] = useState<{ id: string; loading: boolean }>({
     id: props.sessionId ?? uuidv4(),
@@ -28,6 +30,7 @@ export default function Chat(props: { sessionId?: string}) {
   const [messageHistory, setMessageHistory] = useState<ChatBotHistoryItem[]>(
     []
   );
+  const [title, setTitle] = useState<string>("");
   
   /** Loads session history */
   useEffect(() => {
@@ -53,7 +56,6 @@ export default function Chat(props: { sessionId?: string}) {
         await Auth.currentAuthenticatedUser().then((value) => username = value.username);
         if (!username) return;
         const hist = await apiClient.sessions.getSession(props.sessionId,username);
-
         if (hist) {
           
           ChatScrollState.skipNextHistoryUpdate = true;
@@ -68,6 +70,10 @@ export default function Chat(props: { sessionId?: string}) {
                 metadata: x!.metadata!,
                 content: x!.content,
                 messageId: x!.messageId,
+                userFeedback: x!.userFeedback,
+                userId: x!.userId,
+                title: x!.title,
+                createdAt: x!.createdAt,
               }))
           );
 
@@ -77,6 +83,9 @@ export default function Chat(props: { sessionId?: string}) {
           });
         }
         setSession({ id: props.sessionId, loading: false });
+        if (hist.length > 1){
+          setTitle(parseTitle(hist[0].title, hist[0].createdAt, hist[0].userId));
+        }
         setRunning(false);
       } catch (error) {
         console.log(error);
@@ -85,6 +94,12 @@ export default function Chat(props: { sessionId?: string}) {
       }
     })();
   }, [appContext, props.sessionId]);
+
+  const parseTitle = (title: string, timestamp: string, userId: string) => {
+    const dateObject = new Date(timestamp);
+    const dateString = dateObject.toLocaleDateString("en-US", {hour: "numeric", minute: "numeric"});
+    return `${title} | ${dateString} | User ID:${userId}`;
+  }
 
   /** Adds some metadata to the user's feedback */
   const handleFeedback = (feedbackType: "positive" | "negative", idx: number, message: ChatBotHistoryItem, feedbackCategory? : string, feedbackRank? : number, feedbackMessage? : string) => {
@@ -121,13 +136,20 @@ export default function Chat(props: { sessionId?: string}) {
     <div className={styles.chat_container}> 
       <SpaceBetween direction="vertical" size="m">
         
-      {messageHistory.length == 0 && !session?.loading && (
-       <Alert
-          statusIconAriaLabel="Info"
-          header=""
-       >
-        AI Models can make mistakes. Be mindful in validating important information. During the pilot, the tool will also capture your responses to ensure that it is giving accurate information.
-      </Alert> )}
+        {messageHistory.length == 0 && !session?.loading && (
+        <Alert
+            statusIconAriaLabel="Info"
+            header=""
+        >
+          AI Models can make mistakes. Be mindful in validating important information. During the pilot, the tool will also capture your responses to ensure that it is giving accurate information.
+        </Alert> )}
+
+        
+        {messageHistory.length > 0 && isAdmin && (
+          <Box variant="h1">
+            <Link href="/admin/all-sessions"> <strong>{title}</strong> </Link>
+          </Box>
+        )}
 
       
         {messageHistory.map((message, idx) => (

--- a/lib/user-interface/app/src/components/chatbot/types.ts
+++ b/lib/user-interface/app/src/components/chatbot/types.ts
@@ -30,6 +30,10 @@ export interface ChatBotHistoryItem {
     | string[]
     | string[][]
   >;
+  userFeedback: Record<string, string>;
+  userId: string;
+  title: string;
+  createdAt: string;
 }
 
 // Renaming variables and changing types to match new feedback schema

--- a/lib/user-interface/app/src/components/navigation-panel.tsx
+++ b/lib/user-interface/app/src/components/navigation-panel.tsx
@@ -105,8 +105,8 @@ export default function NavigationPanel() {
         type: "section",
         text: "Admin",
         items: [
-          { type: "link", text: "Data", href: "/admin/data" },
-          { type: "link", text: "User Feedback", href: "/admin/user-feedback" },
+          { type: "link", text: "Documents", href: "/admin/data" },
+          { type: "link", text: "Message Feedback", href: "/admin/user-feedback" },
           { type: "link", text: "All Sessions", href: "/admin/all-sessions" }
         ],
       },)

--- a/lib/user-interface/app/src/pages/admin/all-sessions-page.tsx
+++ b/lib/user-interface/app/src/pages/admin/all-sessions-page.tsx
@@ -7,8 +7,7 @@ import {
 } from "@cloudscape-design/components";
 import BaseAppLayout from "../../components/base-app-layout";
 import useOnFollow from "../../common/hooks/use-on-follow";
-import FeedbackTab from "./feedback-tab";
-import FeedbackPanel from "../../components/feedback-panel";
+import AllSessionsTab from "./all-sessions-tab";
 import { CHATBOT_NAME } from "../../common/constants";
 import { useState, useEffect } from "react";
 import { useAdmin } from "../../common/admin-context.js";
@@ -17,7 +16,7 @@ import { useAdmin } from "../../common/admin-context.js";
 export default function AllSessionsPage() {
   const isAdmin = useAdmin();
   const onFollow = useOnFollow();  
-  const [feedback, setFeedback] = useState<any>({});
+  const [session, setSession] = useState<any>({});
   
   /** If they are not an admin, show a page indicating so */
   if (!isAdmin) {
@@ -49,7 +48,6 @@ export default function AllSessionsPage() {
               text: CHATBOT_NAME,
               href: "/",
             },
-  
             {
               text: "All Sessions",
               href: "/admin/all-sessions",
@@ -57,11 +55,10 @@ export default function AllSessionsPage() {
           ]}
         />
       }
-      splitPanel={<FeedbackPanel selectedFeedback={feedback}/>}
       content={
-        <ContentLayout header={<Header variant="h1">View Feedback</Header>}>
+        <ContentLayout header={<Header variant="h1">View All Sessions</Header>}>
           <SpaceBetween size="l">
-                <FeedbackTab updateSelectedFeedback={setFeedback}/>
+                <AllSessionsTab updateSelectedSession={setSession}/>
           </SpaceBetween>
         </ContentLayout>
       }

--- a/lib/user-interface/app/src/pages/admin/all-sessions-tab.tsx
+++ b/lib/user-interface/app/src/pages/admin/all-sessions-tab.tsx
@@ -21,13 +21,12 @@ import { Utils } from "../../common/utils";
 import { useCollection } from "@cloudscape-design/collection-hooks";
 import React from 'react';
 import { useNotifications } from "../../components/notif-manager";
-import { feedbackCategories } from '../../common/constants'
 
-export interface FeedbackTabProps {
-  updateSelectedFeedback: React.Dispatch<any>;
+export interface AllSessionsTabProps {
+  updateSelectedSession: React.Dispatch<any>;
 }
 
-export default function FeedbackTab(props: FeedbackTabProps) {
+export default function AllSessionsTab(props: AllSessionsTabProps) {
   const appContext = useContext(AppContext);
   const apiClient = new ApiClient(appContext);
   const [loading, setLoading] = useState(true);
@@ -41,6 +40,10 @@ export default function FeedbackTab(props: FeedbackTabProps) {
     selectedOption,
     setSelectedOption
   ] = React.useState({ label: "All Feedback", value: "any" });
+  const [
+    hasReviewed,
+    setHasReviewed
+  ] = React.useState({ label: "All Reviews", value: "any" });
   const [value, setValue] = React.useState<DateRangePickerProps.AbsoluteValue>({
     type: "absolute",
     startDate: (new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1)).toISOString().split("T")[0],
@@ -49,129 +52,87 @@ export default function FeedbackTab(props: FeedbackTabProps) {
   const [preferences, setPreferences] = useState({ pageSize: 20 });
   const { addNotification, removeNotification } = useNotifications();
 
-  /** Theoretically handles pagination but I think it works without this actually */
   const { items, collectionProps, paginationProps } = useCollection(
-    pages, {
-    filtering: {
-      empty: (
-        <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-          <SpaceBetween size="m">
-            <b>No feedback</b>
-          </SpaceBetween>
-        </Box>
-      ),
-    },
-    pagination: { pageSize: preferences.pageSize },
-    sorting: {
-      defaultState: {
-        sortingColumn: {
-          sortingField: "CreatedAt",
-        },
-        isDescending: true,
+    pages, 
+    {
+      filtering: {
+        empty: (
+          <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+            <SpaceBetween size="m">
+              <b>No feedback</b>
+            </SpaceBetween>
+          </Box>
+        ),
       },
-    },
-    selection: {},
-  });
+      pagination: { pageSize: preferences.pageSize },
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: "time_stamp",
+          },
+          isDescending: true,
+        },
+      },
+      selection: {},
+    }
+  );
 
-  /** This is the memoized function that is used to get feedback. It takes in a
-   * page index to set the data locally to the correct page as well as a token that the
-   * API uses to paginate the results.
-   */
-  const getFeedback = useCallback(
+  const getAllSessions = useCallback(
     async () => {
       setLoading(true);
       try {
-        const result = await apiClient.userFeedback.getUserFeedback(selectedOption.value, value.startDate + "T00:00:00", value.endDate + "T23:59:59")
-        console.log("Testing getuserfeedback function: ")
-        console.log(result.Items);
-        setPages(result.Items);
+        const result = await apiClient.sessions.getAllSessions(value.startDate + "T00:00:00", value.endDate + "T23:59:59", selectedOption.value, hasReviewed.value)
+        needsRefresh.current = false;
+        setPages(result);
       } catch (error) {
+        console.log(error);
         console.error(Utils.getErrorMessage(error));
+        setPages([]);
       }
       setLoading(false);
     },
-    [appContext, selectedOption, value, needsRefresh]
+    [appContext, selectedOption, value, needsRefresh, hasReviewed]
   );
 
-
-  /** The getFeedback function is a memoized function.
-   * When any of the filters change, getFeedback will also change and we therefore need a refresh
+  /** The getAllSessions function is a memoized function.
+   * When any of the filters change, getAllSessions will also change and we therefore need a refresh
    */
   useEffect(() => {
     setCurrentPageIndex(1);
     setSelectedItems([]);
-    console.log("needs refresh!")
-    getFeedback();
-  }, [getFeedback]);
-
+    console.log("refresh");
+    getAllSessions();
+  }, [getAllSessions]);
 
   /** Handles page refreshes */
   const refreshPage = async () => {
-    await getFeedback();
+    await getAllSessions();
   };
 
 
-  const columnDefinitions = getColumnDefinition("feedback");
+  const columnDefinitions = getColumnDefinition("session");
 
-  /** Deletes all selected feedback */
-  const deleteSelectedFeedback = async () => {
-    if (!appContext) return;
-    setLoading(true);
-    setShowModalDelete(false);
-    const apiClient = new ApiClient(appContext);
-    await Promise.all(
-      selectedItems.map((s) => apiClient.userFeedback.deleteFeedback(s.Topic, s.CreatedAt))
-    );
-    await getFeedback();
-    setSelectedItems([])
-    setLoading(false);
-  };
-
-
-
+  console.log("Pagination props");
+  console.log(paginationProps);
   return (
     <>
-      <Modal
-        onDismiss={() => setShowModalDelete(false)}
-        visible={showModalDelete}
-        footer={
-          <Box float="right">
-            <SpaceBetween direction="horizontal" size="xs">
-              {" "}
-              <Button variant="link" onClick={() => setShowModalDelete(false)}>
-                Cancel
-              </Button>
-              <Button variant="primary" onClick={deleteSelectedFeedback}>
-                Ok
-              </Button>
-            </SpaceBetween>{" "}
-          </Box>
-        }
-        header={"Delete feedback" + (selectedItems.length > 1 ? "s" : "")}
-      >
-        Do you want to delete{" "}
-        {selectedItems.length == 1
-          ? `Feedback ${selectedItems[0].FeedbackID!}?`
-          : `${selectedItems.length} Feedback?`}
-      </Modal>
       <I18nProvider locale="en" messages={[messages]}>
 
 
         <Table
           {...collectionProps}
           loading={loading}
-          loadingText={`Loading Feedback`}
+          loadingText={`Loading Sessions`}
           columnDefinitions={columnDefinitions}
           selectionType="single"
           onSelectionChange={({ detail }) => {
-            // console.log(detail);
-            // needsRefresh.current = true;
-            props.updateSelectedFeedback(detail.selectedItems[0])
+            props.updateSelectedSession(detail.selectedItems[0])
             setSelectedItems(detail.selectedItems);
           }}
           selectedItems={selectedItems}
           items={items}
-          trackBy="FeedbackID"
+          trackBy="session_id"
+          resizableColumns
           preferences={
             <CollectionPreferences
               onConfirm={({ detail }) =>
@@ -271,14 +232,25 @@ export default function FeedbackTab(props: FeedbackTabProps) {
                   <Select
                     selectedOption={selectedOption}
                     onChange={({ detail }) => {
-                      /** If the topic changes, refresh all of the feedback */
+                      /** If the feedback status changes, refresh all of the feedback */
                       needsRefresh.current = true;
                       setSelectedOption({ label: detail.selectedOption.label!, value: detail.selectedOption.value });
                     }}
-                    placeholder="Choose a category"
-                    options={[{label : "All Feedback", value: "any", disabled: false}, ...feedbackCategories]}
+                    placeholder="Select Status"
+                    options={[{label : "All Feedback", value: "any", disabled: false}, {label : "Yes", value: "yes", disabled: false}, {label : "No", value: "no", disabled: false}]}
+                  />
+                  <Select
+                    selectedOption={hasReviewed}
+                    onChange={({ detail }) => {
+                      /** If the review status changes, refresh all of the feedback */
+                      needsRefresh.current = true;
+                      setHasReviewed({ label: detail.selectedOption.label!, value: detail.selectedOption.value });
+                    }}
+                    placeholder="Select Status"
+                    options={[{label : "All Reviews", value: "any", disabled: false}, {label : "Yes", value: "yes", disabled: false}, {label : "No", value: "no", disabled: false}]}
                   />
                   <Button iconName="refresh" onClick={(event) => refreshPage()} />
+                  {/* TODO: No Lambda functionality for downloading session data */}
                   <Button
                     variant="primary"
                     onClick={() => {
@@ -286,7 +258,8 @@ export default function FeedbackTab(props: FeedbackTabProps) {
                       const id = addNotification("success", "Your files have been downloaded.")
                       Utils.delay(3000).then(() => removeNotification(id));
                     }}
-                  >Download</Button>
+                  >Download All</Button>
+                  {/* No Lambda functionality for deleting session data 
                   <Button
                     variant="primary"
                     disabled={selectedItems.length == 0}
@@ -295,21 +268,19 @@ export default function FeedbackTab(props: FeedbackTabProps) {
                     }}
                     data-testid="submit">
                     Delete
-                  </Button>
+                  </Button> */}
                 </SpaceBetween>
               }
               description="Please expect a delay for your changes to be reflected. Press the refresh button to see the latest changes."
             >
-              {"Feedback"}
+              {"All Sessions"}
 
             </Header>
           }
           empty={
-            <Box textAlign="center">No feedback available</Box>
+            <Box textAlign="center">No sessions available</Box>
           }
-          pagination={
-            <Pagination {...paginationProps} />
-          }
+          pagination={<Pagination {...paginationProps} />}
         />
       </I18nProvider>
     </>

--- a/lib/user-interface/app/src/pages/admin/all-sessions-tab.tsx
+++ b/lib/user-interface/app/src/pages/admin/all-sessions-tab.tsx
@@ -158,7 +158,7 @@ export default function AllSessionsTab(props: AllSessionsTabProps) {
       width: 600,
       minWidth: 200,
       cell: (item) => item.has_review === "No"? 
-        <strong> <Link href="#" variant="secondary" onFollow={async(e) => {e.preventDefault(); await updateSelectedReview(true, item.review_id, item.session_id); window.location.href=`/chatbot/playground/${item.session_id}`}}>{item.title}</Link></strong>:
+        <strong> <Link href={`/chatbot/playground/${item.session_id}`} variant="secondary" onFollow={async(e) => {e.preventDefault(); await updateSelectedReview(true, item.review_id, item.session_id); window.location.href=`/chatbot/playground/${item.session_id}`}}>{item.title}</Link></strong>:
         <Link variant="secondary" href={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>,
       isRowHeader: true,
     },

--- a/lib/user-interface/app/src/pages/admin/all-sessions-tab.tsx
+++ b/lib/user-interface/app/src/pages/admin/all-sessions-tab.tsx
@@ -125,12 +125,16 @@ export default function AllSessionsTab(props: AllSessionsTabProps) {
     if (!username) return;
     const apiClient = new ApiClient(appContext);
 
-    if (session_id) {
+    // If session ID is provided, then this is invoked by the Link onFollow event 
+    if (session_id) { 
       await apiClient.sessions.updateReview(review_id, session_id, username, isReviewed);
-    } else {
-    await Promise.all(
-      selectedItems.map((s) => apiClient.sessions.updateReview(s.review_id, s.session_id, username, isReviewed))
-    );}
+    } 
+    // If not, then this is triggered by the buttons and the list needs to be refreshed
+    else {
+      await Promise.all(
+        selectedItems.map((s) => apiClient.sessions.updateReview(s.review_id, s.session_id, username, isReviewed))
+      );
+    }
     await getAllSessions();
     setSelectedItems([])
     setLoading(false);
@@ -153,10 +157,9 @@ export default function AllSessionsTab(props: AllSessionsTabProps) {
       sortingField: "title",
       width: 600,
       minWidth: 200,
-      // cell: (item) => item.FeedbackType,
       cell: (item) => item.has_review === "No"? 
-        <strong> <Link href={`/chatbot/playground/${item.session_id}`} onFollow={() => updateSelectedReview(true, item.review_id, item.session_id)}>{item.title}</Link></strong>:
-        <Link href={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>,
+        <strong> <Link href="#" variant="secondary" onFollow={async(e) => {e.preventDefault(); await updateSelectedReview(true, item.review_id, item.session_id); window.location.href=`/chatbot/playground/${item.session_id}`}}>{item.title}</Link></strong>:
+        <Link variant="secondary" href={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>,
       isRowHeader: true,
     },
     {

--- a/lib/user-interface/app/src/pages/admin/columns.tsx
+++ b/lib/user-interface/app/src/pages/admin/columns.tsx
@@ -38,7 +38,7 @@ const FEEDBACK_COLUMN_DEFINITIONS = [
   {
     id: "feedbackType",
     header: "SENTIMENT",
-    cell: (item) => <Link href={`/chatbot/playground/${item.SessionID}`}>{item.FeedbackType}</Link>,
+    cell: (item) => <Link href={`/chatbot/playground/${item.SessionID}`} variant="secondary">{item.FeedbackType}</Link>,
     isRowHeader: true,
   },
   {

--- a/lib/user-interface/app/src/pages/admin/columns.tsx
+++ b/lib/user-interface/app/src/pages/admin/columns.tsx
@@ -1,6 +1,7 @@
 import { AdminDataType } from "../../common/types";
 import { DateTime } from "luxon";
 import { Utils } from "../../common/utils";
+import { Link } from "react-router-dom";
 
 const FILES_COLUMN_DEFINITIONS = [
   {
@@ -60,6 +61,35 @@ const FEEDBACK_COLUMN_DEFINITIONS = [
 
 ];
 
+const SESSION_COLUMN_DEFINITIONS = [
+  {
+    id: "time_stamp",
+    header: "DATE",
+    sortingField: "time_stamp",
+    cell: (item) =>
+      DateTime.fromISO(new Date(item.time_stamp).toISOString()).toLocaleString(
+        DateTime.DATETIME_SHORT
+      ),
+  },
+  {
+    id: "title",
+    header: "TITLE",
+    sortingField: "title",
+    width: 600,
+    minWidth: 200,
+    // cell: (item) => item.FeedbackType,
+    cell: (item) => (<Link to={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>),
+    isRowHeader: true,
+  },
+  {
+    id: "has_feedback",
+    header: "HAS FEEDBACK",
+    sortingField: "has_feedback",
+    cell: (item) => item.has_feedback,
+    isRowHeader: true,
+  },
+];
+
 /** This is exposed as a function because the code that this is based off of
  * originally supported many more distinct file types.
  */
@@ -69,6 +99,8 @@ export function getColumnDefinition(documentType: AdminDataType) {
       return FILES_COLUMN_DEFINITIONS;   
     case "feedback":
       return FEEDBACK_COLUMN_DEFINITIONS;
+    case "session":
+      return SESSION_COLUMN_DEFINITIONS;
     default:
       return [];
   }

--- a/lib/user-interface/app/src/pages/admin/columns.tsx
+++ b/lib/user-interface/app/src/pages/admin/columns.tsx
@@ -2,6 +2,7 @@ import { AdminDataType } from "../../common/types";
 import { DateTime } from "luxon";
 import { Utils } from "../../common/utils";
 import { Link } from "react-router-dom";
+import TextContent from "@cloudscape-design/components/text-content";
 
 const FILES_COLUMN_DEFINITIONS = [
   {
@@ -67,9 +68,9 @@ const SESSION_COLUMN_DEFINITIONS = [
     header: "DATE",
     sortingField: "time_stamp",
     cell: (item) =>
-      DateTime.fromISO(new Date(item.time_stamp).toISOString()).toLocaleString(
-        DateTime.DATETIME_SHORT
-      ),
+      item.has_review === "No"? 
+        <strong> {DateTime.fromISO(new Date(item.time_stamp).toISOString()).toLocaleString(DateTime.DATETIME_SHORT)} </strong>:
+        DateTime.fromISO(new Date(item.time_stamp).toISOString()).toLocaleString(DateTime.DATETIME_SHORT),
   },
   {
     id: "title",
@@ -78,14 +79,18 @@ const SESSION_COLUMN_DEFINITIONS = [
     width: 600,
     minWidth: 200,
     // cell: (item) => item.FeedbackType,
-    cell: (item) => (<Link to={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>),
+    cell: (item) => item.has_review === "No"? 
+      <strong> <Link to={`/chatbot/playground/${item.session_id}`}>{item.title}</Link></strong>:
+      <Link to={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>,
     isRowHeader: true,
   },
   {
     id: "has_feedback",
     header: "HAS FEEDBACK",
     sortingField: "has_feedback",
-    cell: (item) => item.has_feedback,
+    cell: (item) => item.has_review === "No"?
+      <strong> {item.has_feedback} </strong>:
+      item.has_feedback,
     isRowHeader: true,
   },
 ];

--- a/lib/user-interface/app/src/pages/admin/columns.tsx
+++ b/lib/user-interface/app/src/pages/admin/columns.tsx
@@ -1,7 +1,7 @@
 import { AdminDataType } from "../../common/types";
 import { DateTime } from "luxon";
 import { Utils } from "../../common/utils";
-import { Link } from "react-router-dom";
+import { Link } from "@cloudscape-design/components";
 import TextContent from "@cloudscape-design/components/text-content";
 
 const FILES_COLUMN_DEFINITIONS = [
@@ -38,7 +38,7 @@ const FEEDBACK_COLUMN_DEFINITIONS = [
   {
     id: "feedbackType",
     header: "SENTIMENT",
-    cell: (item) => item.FeedbackType,
+    cell: (item) => <Link href={`/chatbot/playground/${item.SessionID}`}>{item.FeedbackType}</Link>,
     isRowHeader: true,
   },
   {
@@ -80,8 +80,8 @@ const SESSION_COLUMN_DEFINITIONS = [
     minWidth: 200,
     // cell: (item) => item.FeedbackType,
     cell: (item) => item.has_review === "No"? 
-      <strong> <Link to={`/chatbot/playground/${item.session_id}`}>{item.title}</Link></strong>:
-      <Link to={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>,
+      <strong> <Link href={`/chatbot/playground/${item.session_id}`}>{item.title}</Link></strong>:
+      <Link href={`/chatbot/playground/${item.session_id}`}>{item.title}</Link>,
     isRowHeader: true,
   },
   {

--- a/lib/user-interface/app/src/pages/admin/feedback-tab.tsx
+++ b/lib/user-interface/app/src/pages/admin/feedback-tab.tsx
@@ -209,6 +209,11 @@ export default function FeedbackTab(props: FeedbackTabProps) {
             <Header
               actions={
                 <SpaceBetween direction="horizontal" size="xs">
+                  <Button 
+                    variant="primary"
+                    onClick={(event) => refreshPage()}>
+                      Update Data
+                  </Button>
                   <DateRangePicker
                     onChange={({ detail }) => {
                       /** If the date changes, refresh all of the feedback. This
@@ -292,7 +297,7 @@ export default function FeedbackTab(props: FeedbackTabProps) {
                     placeholder="Choose a category"
                     options={[{label : "All Feedback", value: "any", disabled: false}, ...feedbackCategories]}
                   />
-                  <Button iconName="refresh" onClick={(event) => refreshPage()} />
+                  {/* <Button iconName="refresh" onClick={(event) => refreshPage()} /> */}
                   <Button
                     variant="primary"
                     onClick={() => {

--- a/lib/user-interface/app/src/pages/admin/feedback-tab.tsx
+++ b/lib/user-interface/app/src/pages/admin/feedback-tab.tsx
@@ -46,12 +46,12 @@ export default function FeedbackTab(props: FeedbackTabProps) {
     startDate: (new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1)).toISOString().split("T")[0],
     endDate: (new Date()).toISOString().split("T")[0]
   });
-  const [preferences, setPreferences] = useState({ pageSize: 20 });
+  const [preferences, setPreferences] = useState({ pageSize: 10 });
   const { addNotification, removeNotification } = useNotifications();
 
   /** Theoretically handles pagination but I think it works without this actually */
   const { items, collectionProps, paginationProps } = useCollection(
-    pages, {
+    [...pages], {
     filtering: {
       empty: (
         <Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
@@ -61,7 +61,7 @@ export default function FeedbackTab(props: FeedbackTabProps) {
         </Box>
       ),
     },
-    pagination: { pageSize: preferences.pageSize },
+      pagination: { pageSize: preferences.pageSize },
     sorting: {
       defaultState: {
         sortingColumn: {
@@ -81,10 +81,17 @@ export default function FeedbackTab(props: FeedbackTabProps) {
     async () => {
       setLoading(true);
       try {
-        const result = await apiClient.userFeedback.getUserFeedback(selectedOption.value, value.startDate + "T00:00:00", value.endDate + "T23:59:59")
-        console.log("Testing getuserfeedback function: ")
+        const result = await apiClient.userFeedback.getUserFeedback(
+          selectedOption.value,
+          value.startDate + "T00:00:00",
+          value.endDate + "T23:59:59"
+        );
+
+        console.log("Testing getuserfeedback function: ");
         console.log(result.Items);
-        setPages(result.Items);
+
+        setPages([...result.Items]);  // Ensure state update is recognized
+        setCurrentPageIndex(1);       // Reset pagination when data changes
       } catch (error) {
         console.error(Utils.getErrorMessage(error));
       }
@@ -103,6 +110,13 @@ export default function FeedbackTab(props: FeedbackTabProps) {
     console.log("needs refresh!")
     getFeedback();
   }, [getFeedback]);
+
+  useEffect(() => {
+    console.log("🔍 Updated preferences.pageSize:", preferences.pageSize);
+    console.log("🔍 Total items in pages:", pages.length);
+    console.log("🔍 Items currently displayed:", items.length);
+    console.log("🔍 Pagination props:", paginationProps);
+  }, [preferences.pageSize, pages, paginationProps, items]);
 
 
   /** Handles page refreshes */
@@ -175,7 +189,7 @@ export default function FeedbackTab(props: FeedbackTabProps) {
           preferences={
             <CollectionPreferences
               onConfirm={({ detail }) =>
-                setPreferences({ pageSize: detail.pageSize ?? 20 })
+                setPreferences({ pageSize: detail.pageSize ?? 10 })
               }
               title="Preferences"
               confirmLabel="Confirm"

--- a/lib/user-interface/app/src/styles/chat.module.scss
+++ b/lib/user-interface/app/src/styles/chat.module.scss
@@ -214,3 +214,12 @@
   opacity: 1 !important;
   pointer-events: none; /* Disable pointer events for the selected icon */
 }
+
+.markdownContainer {
+  // overflow: hidden; /* Hides both vertical and horizontal scrollbars */
+  background-color: awsui.$color-charts-line-grid;
+  // overflow: scroll;
+  border-radius: 5px;
+  padding: 5px;
+  white-space : pre-wrap !important;
+}

--- a/lib/user-interface/generate-app.ts
+++ b/lib/user-interface/generate-app.ts
@@ -115,9 +115,9 @@ export class Website extends Construct {
         ...((process.env.CLOUDFRONT_CUSTOM_DOMAIN_URL && process.env.CLOUDFRONT_CUSTOM_DOMAIN_SSL_CERTIFICATE_ARN) ? {
           viewerCertificate: cf.ViewerCertificate.fromAcmCertificate(
             acm.Certificate.fromCertificateArn(this, 'CloudfrontAcm', process.env.CLOUDFRONT_CUSTOM_DOMAIN_SSL_CERTIFICATE_ARN),
-            // {
-            //   aliases: [process.env.CLOUDFRONT_CUSTOM_DOMAIN_URL]
-            // }
+            {
+              aliases: [process.env.CLOUDFRONT_CUSTOM_DOMAIN_URL]
+            }
           )
         } : {})
       }


### PR DESCRIPTION
All-Sessions updates: 
- Added "All Sessions" page
- Pagination in sessions table
- Updated Lambda handlers
- Session status is changed to "reviewed" on click. Users can reset it to "unreviewed" manually.
- Updated dropdown options to "All Review Statuses, Yes, No" and "All Feedback Statuses, Yes, No"

Message Feedback window updates:
- Renamed "User Feedback" panel to "Message Feedback"
- Clicking on feedback item redirects user to the full session (same behavior as the All-Sessions window)

General updates:
- Added user feedback under each chatbot message for admin review
- Added title at the top of each session for admin review
- Replaced refresh button with "Update Data" button to match mockups
- Renamed "Data" tab to "Documents"

@xuhongkang @mmaterman @vigaeatery 